### PR TITLE
better AssertionError messages when actual or expected is null

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,7 +196,7 @@ exports.betterErrors = function (assertion) {
         return assertion;
     }
     var e = assertion.error;
-    if (e.actual && e.expected) {
+    if ('actual' in e && 'expected' in e) {
         var actual = util.inspect(e.actual, false, 10).replace(/\n$/, '');
         var expected = util.inspect(e.expected, false, 10).replace(/\n$/, '');
         var multiline = (

--- a/test/test-bettererrors.js
+++ b/test/test-bettererrors.js
@@ -37,6 +37,19 @@ exports.testEqual = function (test) {
     }
 };
 
+exports.testEqualNull = function (test) {
+    try {
+        assert.equal(null, false);
+    } catch (error) {
+        var betterErrorString = betterErrorStringFromError(error);
+        performBasicChecks(betterErrorString);
+        betterErrorString.should.include("null");
+        betterErrorString.should.include("false");
+        betterErrorString.should.include("==");
+        test.done();
+    }
+};
+
 /**
  * Test an AssertionError that does not contain actual, expected or operator values.
  * @param test the test object from nodeunit


### PR DESCRIPTION
(or false or undefined).

betterErrors seems to be using `(e.actual && e.expected)` as a test for whether e is an AssertionError (and not a generic Error), but this fails when actual or expected is falsey.

Instead check if it has those properties, regardless of their value.
